### PR TITLE
Move k8s manifest to a subdir

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ jobs:
                 namespace: default
                 server: "https://kubernetes.default.svc"
               source:
-                path: app
+                path: app/k8s
                 repoURL: << pipeline.project.git_url >>
                 targetRevision: ${CIRCLE_BRANCH}
               project: default

--- a/app/k8s/helloapp.yml
+++ b/app/k8s/helloapp.yml
@@ -34,5 +34,3 @@ spec:
           image: public.ecr.aws/nginx/nginx:1.23
           ports:
             - containerPort: 80
-
-


### PR DESCRIPTION
ArgoCD is reading the package.json file as the k8s manifest which is why deploy is failing. Moving the manifest to a subdir should resolve it

https://app.circleci.com/pipelines/github/CircleCI-Public/eks-devops-template/14/workflows/3ea55bad-3863-4dd5-a908-0b4de06d16fe/jobs/33?invite=true#step-110-2018_140
<img width="1177" alt="image" src="https://github.com/CircleCI-Public/eks-devops-template/assets/22925321/0c8c5c18-63ff-47d5-9bc7-936bda148f25">

